### PR TITLE
readme: update minimum go version

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This is a parallel S3 and local filesystem execution tool.
 
 ## Installation ##
 
-You'll need [Go 1.7+](https://golang.org/dl) to install `s5cmd`.
+You'll need [Go 1.8+](https://golang.org/dl) to install `s5cmd`.
 
     go get -u github.com/peakgames/s5cmd
 


### PR DESCRIPTION
Vendored package `github.com/posener/complete` uses `os.Executable`, and it's added in Go 1.8.

```
~$ go version
go version go1.7 linux/amd64
~$ go get -u github.com/peakgames/s5cmd
$GOPATH/src/github.com/peakgames/s5cmd/vendor/github.com/posener/complete/cmd/install/install.go:75: undefined: os.Executable
```