### PR TITLE
Endpoint support for S3 compatible services

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ s5cmd -cmp-install
 ```
 This will add a few lines (depending on configuration) to your `.bashrc` or `.zshrc` file. After installation, run `source .bashrc` (or restart your shell) to activate the changes.
 
+> Note: Auto-completion always works with AWS Endpoint, `-endpoint-url` does not override it's behaviour.
+
 #### Examples ####
 
 To utilize shell autocompletion, use the `<tab>` key on the shell CLI. If there is more than one match, nothing will happen until a second `<tab>` is hit, which then will show options. Examples:
@@ -68,6 +70,8 @@ Options:
     	Multipart chunk size in MB for downloads (default 50)
   -dw int
     	Download concurrency (single file) (default 5)
+  -endpoint-url string
+    	Override default URL with the given one
   -f string
     	Commands-file or - for stdin
   -gops
@@ -80,12 +84,17 @@ Options:
     	Retry S3 operations N times before failing (default 10)
   -stats
     	Always print stats
+  -uninstall
+    	Uninstall completion for s5cmd command
   -us int
-    	Multipart chunk size in MB for uploads (default 50, auto calculated)
+    	Multipart chunk size in MB for uploads (default 50)
   -uw int
     	Upload concurrency (single file) (default 5)
   -version
     	Prints current version
+  -vv
+    	Verbose output
+  -y	Don't prompt user for typing 'yes'
 
 Commands:
     !, cp, du, exit, get, ls, mv, rm

--- a/complete/complete.go
+++ b/complete/complete.go
@@ -202,7 +202,7 @@ func s3predictor(a cmp.Args) []string {
 	}
 
 	// Quickly create a new session with defaults
-	ses, err := core.NewAwsSession(-1, "")
+	ses, err := core.NewAwsSession(-1, "", "")
 	if err != nil {
 		return nil
 	}

--- a/core/s3.go
+++ b/core/s3.go
@@ -195,5 +195,7 @@ func GetSessionForBucket(svc *s3.S3, bucket string) (*session.Session, error) {
 		return nil, err
 	}
 
-	return NewAwsSession(-1, "", *o.LocationConstraint)
+	endpointURL := svc.Endpoint
+
+	return NewAwsSession(-1, endpointURL, *o.LocationConstraint)
 }

--- a/core/s3.go
+++ b/core/s3.go
@@ -195,5 +195,5 @@ func GetSessionForBucket(svc *s3.S3, bucket string) (*session.Session, error) {
 		return nil, err
 	}
 
-	return NewAwsSession(-1, *o.LocationConstraint)
+	return NewAwsSession(-1, "", *o.LocationConstraint)
 }

--- a/s5cmd.go
+++ b/s5cmd.go
@@ -50,6 +50,7 @@ func main() {
 	var (
 		numWorkers    int
 		cmdFile       string
+		endpointURL   string
 		ulPartSize    int
 		ulConcurrency int
 		dlPartSize    int
@@ -58,6 +59,7 @@ func main() {
 	)
 
 	flag.StringVar(&cmdFile, "f", "", "Commands-file or - for stdin")
+	flag.StringVar(&endpointURL, "endpoint-url", "", "Override default URL with the given one")
 	flag.IntVar(&numWorkers, "numworkers", defaultNumWorkers, fmt.Sprintf("Number of worker goroutines. Negative numbers mean multiples of the CPU core count."))
 	flag.IntVar(&dlConcurrency, "dw", s3manager.DefaultDownloadConcurrency, "Download concurrency (single file)")
 	flag.IntVar(&dlPartSize, "ds", 50, "Multipart chunk size in MB for downloads")
@@ -139,6 +141,8 @@ func main() {
 		numWorkers = minNumWorkers
 	}
 
+	endpointURL = strings.TrimSpace(endpointURL)
+
 	startTime := time.Now()
 
 	if !cmdMode {
@@ -176,6 +180,7 @@ func main() {
 			DownloadChunkSizeBytes: dlPartSizeBytes,
 			DownloadConcurrency:    dlConcurrency,
 			Retries:                retries,
+			EndpointURL:            endpointURL,
 		}, &s)
 	if cmdMode {
 		wp.RunCmd(cmd)


### PR DESCRIPTION
Adds cli flag to override default endpoint, so it can be used with other S3 compatible services.
resolve #4 
